### PR TITLE
Change calculation of circles radius

### DIFF
--- a/star-rating.vue
+++ b/star-rating.vue
@@ -85,10 +85,10 @@ export default {
       let centerY = this.styleStarWidth / 2;
 
       let innerCircleArms = 5; // a 5 arms star
-
-      let innerRadius = this.styleStarWidth / innerCircleArms;
+      
+      let outerRadius = this.styleStarWidth / 2 ;
       let innerOuterRadiusRatio = 2.5; // Unique value - determines fatness/sharpness of star
-      let outerRadius = innerRadius * innerOuterRadiusRatio;
+      let innerRadius = outerRadius / innerOuterRadiusRatio;
 
       return this.calcStarPoints(
         centerX,

--- a/star-rating.vue
+++ b/star-rating.vue
@@ -87,8 +87,8 @@ export default {
       let innerCircleArms = 5; // a 5 arms star
       
       let outerRadius = this.styleStarWidth / 2 ;
-      let innerOuterRadiusRatio = 2.5; // Unique value - determines fatness/sharpness of star
-      let innerRadius = outerRadius / innerOuterRadiusRatio;
+      let ratio = 2.5; // Unique value - determines fatness/sharpness of star - only change here
+      let innerRadius = outerRadius / Math.max(1, ratio); // prevent values smaller 1 - so change only ratio above.
 
       return this.calcStarPoints(
         centerX,


### PR DESCRIPTION
Hey :)

I am using your star in a project of mine (a Google DataStudio vis - can drop you the link if interested in that) and there I noticed the "funny" Behaviour that the stars don't constrain to the boxes they should fit in if you're going crazy with the chubbiness (or rather skinniness).

This proposal fixes this by creating a circle that exactly fits into the rectangle that the star should fit into and then calculates the inner circle based on the ratio and the outer circle. You did the other way around.

cheers
Stefanie